### PR TITLE
Update test:ci script for CI environments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidelines
+
+- Use Conventional Commits style for commit messages (e.g., `feat:`, `fix:`, `docs:`).
+- Run `npm run lint` and `npm run test:ci` before committing.
+- PR descriptions should contain a brief summary and a testing section showing any command outputs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # RoomPlanner
 
+RoomPlanner is an Angular-based tool for planning room layouts and experimenting with furniture arrangements.
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 19.2.11.
+
+## Installation
+
+Install the dependencies before building or serving the project.
+
+```bash
+npm install
+```
 
 ## Development server
 
@@ -36,6 +45,14 @@ ng build
 
 This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
 
+## Linting
+
+Run ESLint to check for style issues:
+
+```bash
+npm run lint
+```
+
 ## Running unit tests
 
 To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
@@ -43,6 +60,16 @@ To execute unit tests with the [Karma](https://karma-runner.github.io) test runn
 ```bash
 ng test
 ```
+For environments without a browser, use:
+
+```bash
+npm run test:ci
+```
+
+The `test:ci` script attempts to locate Chrome or Chromium automatically. If it
+fails, set the `CHROME_BIN` environment variable to the full path of your
+browser executable.
+
 
 ## Running end-to-end tests
 
@@ -57,3 +84,8 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Contributing
+
+Please use conventional commits and verify lint and test commands succeed before submitting a pull request.
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "test:ci": "ng test --watch=false --browsers=ChromeHeadlessCI",
+    "test:ci": "CHROME_BIN=$(command -v chromium-browser || command -v chromium || command -v google-chrome-stable || command -v google-chrome || true) ng test --watch=false --browsers=ChromeHeadlessCI",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },


### PR DESCRIPTION
## Summary
- attempt to auto-detect Chrome for the `test:ci` script
- mention `CHROME_BIN` env var in README

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_685e7582bfc0832c8c6258f5eced38e4