### PR TITLE
Fix table movement within room

### DIFF
--- a/src/app/room-planner/services/element-management.service.spec.ts
+++ b/src/app/room-planner/services/element-management.service.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { ElementManagementService } from './element-management.service';
+import { Room } from '../interfaces/room.interface';
+import {
+  ElementTypeEnum,
+  ShapeTypeEnum,
+} from '../interfaces/room-element.interface';
+
+describe('ElementManagementService', () => {
+  let service: ElementManagementService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ElementManagementService);
+  });
+
+  it('should clamp table position within room bounds', () => {
+    const room: Room = {
+      width: 100,
+      height: 100,
+      tables: [
+        {
+          id: '1',
+          x: 10,
+          y: 10,
+          width: 20,
+          height: 20,
+          elementType: ElementTypeEnum.TABLE,
+          shapeType: ShapeTypeEnum.RECTANGLE,
+        },
+      ],
+      staticElements: [],
+    };
+
+    const updatedRoom = service.updateElement(room, '1', { x: -10, y: 95 });
+    const table = updatedRoom.tables[0];
+    expect(table.x).toBe(0);
+    expect(table.y).toBe(80);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent tables from moving outside room bounds
- add test for new clamping behaviour

## Testing
- `npm run lint`
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685eed31651c832c85ea4fa7b0b514ab