### PR TITLE
Add mobile-friendly element properties panel

### DIFF
--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -50,8 +50,8 @@
         </div>
       </div>
 
-      <!-- Element Properties Panel -->
-      <div class="lg:col-span-1 order-2">
+      <!-- Element Properties Panel Desktop-->
+      <div class="lg:col-span-1 order-2 hidden lg:block">
         <div
           class="bg-white rounded-2xl shadow-xl border border-gray-200 p-6 sticky top-8"
         >
@@ -63,6 +63,67 @@
             (centerElementEvent)="onCenterElement(selectedId()!)"
           >
           </app-element-properties>
+        </div>
+      </div>
+
+      <!-- Mobile Properties Trigger -->
+      <button
+        class="fixed bottom-6 right-6 z-40 p-4 rounded-full bg-blue-600 text-white shadow-lg lg:hidden"
+        type="button"
+        (click)="toggleMobileProperties()"
+        *ngIf="selectedElement()"
+      >
+        <svg
+          class="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M5 12h14M12 5l7 7-7 7"
+          />
+        </svg>
+      </button>
+
+      <!-- Mobile Properties Panel -->
+      <div
+        class="lg:hidden"
+        *ngIf="showMobileProperties() && selectedElement()"
+      >
+        <div
+          class="fixed inset-x-0 bottom-0 z-50 bg-white border-t rounded-t-2xl shadow-2xl p-6"
+        >
+          <div class="flex justify-end mb-2">
+            <button
+              type="button"
+              (click)="toggleMobileProperties()"
+              class="p-1 text-gray-500 hover:text-gray-700"
+            >
+              <svg
+                class="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+          <app-element-properties
+            [selectedElement]="selectedElement()"
+            (updateElement)="onUpdateElement(selectedId()!, $event)"
+            (deleteElement)="onDeleteElement(selectedId()!)"
+            (duplicateElementEvent)="onDuplicateElement(selectedId()!)"
+            (centerElementEvent)="onCenterElement(selectedId()!)"
+          ></app-element-properties>
         </div>
       </div>
     </div>

--- a/src/app/room-planner/room-planner.component.spec.ts
+++ b/src/app/room-planner/room-planner.component.spec.ts
@@ -20,4 +20,10 @@ describe('RoomPlannerComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should toggle mobile properties visibility', () => {
+    component.showMobileProperties.set(false);
+    component.toggleMobileProperties();
+    expect(component.showMobileProperties()).toBeTrue();
+  });
 });

--- a/src/app/room-planner/room-planner.component.ts
+++ b/src/app/room-planner/room-planner.component.ts
@@ -63,6 +63,8 @@ export class RoomPlannerComponent implements AfterViewInit {
     );
   });
 
+  readonly showMobileProperties = signal(false);
+
   // 🧠 Redraw effect
   constructor() {
     effect(() => {
@@ -230,5 +232,9 @@ export class RoomPlannerComponent implements AfterViewInit {
     const centerY = (room.height - element.height) / 2;
 
     this.onUpdateElement(elementId, { x: centerX, y: centerY });
+  }
+
+  toggleMobileProperties(): void {
+    this.showMobileProperties.update((v) => !v);
   }
 }


### PR DESCRIPTION
## Summary
- add a mobile drawer for element properties
- toggle drawer visibility with new signal
- test drawer toggle logic

## Testing
- `npm run lint`
- `npm run test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685eed84ac14832c9b68258cc44988b2