### PR TITLE
Add mobile-friendly element properties panel

### DIFF
--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -50,8 +50,8 @@
         </div>
       </div>
 
-      <!-- Element Properties Panel -->
-      <div class="lg:col-span-1 order-2">
+      <!-- Element Properties Panel Desktop-->
+      <div class="lg:col-span-1 order-2 hidden lg:block">
         <div
           class="bg-white rounded-2xl shadow-xl border border-gray-200 p-6 sticky top-8"
         >
@@ -63,6 +63,67 @@
             (centerElementEvent)="onCenterElement(selectedId()!)"
           >
           </app-element-properties>
+        </div>
+      </div>
+
+      <!-- Mobile Properties Trigger -->
+      <button
+        class="fixed bottom-6 right-6 z-40 p-4 rounded-full bg-blue-600 text-white shadow-lg lg:hidden"
+        type="button"
+        (click)="toggleMobileProperties()"
+        *ngIf="selectedElement()"
+      >
+        <svg
+          class="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M5 12h14M12 5l7 7-7 7"
+          />
+        </svg>
+      </button>
+
+      <!-- Mobile Properties Panel -->
+      <div
+        class="lg:hidden"
+        *ngIf="showMobileProperties() && selectedElement()"
+      >
+        <div
+          class="fixed inset-x-0 bottom-0 z-50 bg-white border-t rounded-t-2xl shadow-2xl p-6"
+        >
+          <div class="flex justify-end mb-2">
+            <button
+              type="button"
+              (click)="toggleMobileProperties()"
+              class="p-1 text-gray-500 hover:text-gray-700"
+            >
+              <svg
+                class="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+          <app-element-properties
+            [selectedElement]="selectedElement()"
+            (updateElement)="onUpdateElement(selectedId()!, $event)"
+            (deleteElement)="onDeleteElement(selectedId()!)"
+            (duplicateElementEvent)="onDuplicateElement(selectedId()!)"
+            (centerElementEvent)="onCenterElement(selectedId()!)"
+          ></app-element-properties>
         </div>
       </div>
     </div>

--- a/src/app/room-planner/room-planner.component.spec.ts
+++ b/src/app/room-planner/room-planner.component.spec.ts
@@ -20,4 +20,10 @@ describe('RoomPlannerComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should toggle mobile properties visibility', () => {
+    component.showMobileProperties.set(false);
+    component.toggleMobileProperties();
+    expect(component.showMobileProperties()).toBeTrue();
+  });
 });

--- a/src/app/room-planner/room-planner.component.ts
+++ b/src/app/room-planner/room-planner.component.ts
@@ -8,6 +8,7 @@ import {
   ViewChild,
   AfterViewInit,
 } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { ElementPropertiesComponent } from './components/element-properties.component';
 import { JsonManagerComponent } from './components/json-manager.component';
 import { RoomControlsComponent } from './components/room-controls.component';
@@ -31,6 +32,7 @@ import { ElementManagementService } from './services/element-management.service'
   selector: 'app-room-planner',
   templateUrl: './room-planner.component.html',
   imports: [
+    CommonModule,
     RoomControlsComponent,
     JsonManagerComponent,
     ElementPropertiesComponent,
@@ -59,9 +61,11 @@ export class RoomPlannerComponent implements AfterViewInit {
   readonly selectedElement = computed(() => {
     return this.elementService.getSelectedElement(
       this.room(),
-      this.selectedId()
+      this.selectedId(),
     );
   });
+
+  readonly showMobileProperties = signal(false);
 
   // 🧠 Redraw effect
   constructor() {
@@ -78,7 +82,7 @@ export class RoomPlannerComponent implements AfterViewInit {
 
     // Initialize z-indices for any existing elements
     const roomWithZIndices = this.elementService.initializeZIndices(
-      this.room()
+      this.room(),
     );
     this.room.set(roomWithZIndices);
 
@@ -93,7 +97,7 @@ export class RoomPlannerComponent implements AfterViewInit {
   }): void {
     const element = this.elementService.createElement(
       event.elementType,
-      event.shapeType
+      event.shapeType,
     );
 
     this.room.update((room) => {
@@ -135,7 +139,7 @@ export class RoomPlannerComponent implements AfterViewInit {
           // Bring the selected element to front
           const updatedRoom = this.elementService.bringElementToFront(
             this.room(),
-            event.elementId
+            event.elementId,
           );
           this.room.set(updatedRoom);
         }
@@ -175,7 +179,7 @@ export class RoomPlannerComponent implements AfterViewInit {
     const updatedRoom = this.elementService.updateElement(
       this.room(),
       elementId,
-      update
+      update,
     );
     this.room.set(updatedRoom);
   }
@@ -183,35 +187,43 @@ export class RoomPlannerComponent implements AfterViewInit {
   onDeleteElement(elementId: string): void {
     const updatedRoom = this.elementService.deleteElement(
       this.room(),
-      elementId
+      elementId,
     );
     this.room.set(updatedRoom);
     this.selectedId.set(null);
   }
 
   onDuplicateElement(elementId: string): void {
-    const element = this.elementService.getSelectedElement(this.room(), elementId);
+    const element = this.elementService.getSelectedElement(
+      this.room(),
+      elementId,
+    );
     if (!element) return;
 
     const duplicatedElement = this.elementService.createElement(
       element.elementType,
-      element.shapeType || 'rectangle'
+      element.shapeType || 'rectangle',
     );
-    
+
     // Position the duplicate slightly offset from the original
     duplicatedElement.x = element.x + 20;
     duplicatedElement.y = element.y + 20;
     duplicatedElement.width = element.width;
     duplicatedElement.height = element.height;
     duplicatedElement.color = element.color;
-    duplicatedElement.label = element.label ? `${element.label} Copy` : undefined;
+    duplicatedElement.label = element.label
+      ? `${element.label} Copy`
+      : undefined;
 
     this.room.update((room) => {
       switch (element.elementType) {
         case ElementTypeEnum.TABLE:
           return { ...room, tables: [...room.tables, duplicatedElement] };
         case ElementTypeEnum.STATIC:
-          return { ...room, staticElements: [...room.staticElements, duplicatedElement] };
+          return {
+            ...room,
+            staticElements: [...room.staticElements, duplicatedElement],
+          };
         default:
           return room;
       }
@@ -222,7 +234,10 @@ export class RoomPlannerComponent implements AfterViewInit {
   }
 
   onCenterElement(elementId: string): void {
-    const element = this.elementService.getSelectedElement(this.room(), elementId);
+    const element = this.elementService.getSelectedElement(
+      this.room(),
+      elementId,
+    );
     if (!element) return;
 
     const room = this.room();
@@ -230,5 +245,9 @@ export class RoomPlannerComponent implements AfterViewInit {
     const centerY = (room.height - element.height) / 2;
 
     this.onUpdateElement(elementId, { x: centerX, y: centerY });
+  }
+
+  toggleMobileProperties(): void {
+    this.showMobileProperties.update((v) => !v);
   }
 }


### PR DESCRIPTION
## Summary
- add a mobile drawer for element properties
- toggle drawer visibility with new signal
- test drawer toggle logic
- import `CommonModule` so `*ngIf` works

## Testing
- `npm run lint`
- `npm run test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685eed84ac14832c9b68258cc44988b2