### PR TITLE
Implement mobile-friendly layout manager

### DIFF
--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -45,6 +45,13 @@
                 class="block max-w-none border bg-white touch-none select-none"
               >
               </canvas>
+              <div
+                class="absolute inset-x-0 bottom-0 p-2 text-center text-xs text-white bg-black/60 rounded-b"
+                *ngIf="showElementGuide()"
+              >
+                Drag elements to move them. Use the properties panel to edit or
+                delete.
+              </div>
             </div>
           </div>
         </div>
@@ -128,16 +135,62 @@
       </div>
     </div>
 
-    <!-- JSON Manager -->
-    <div class="mt-8">
-      <div class="bg-white rounded-2xl shadow-xl border border-gray-200 p-6">
+    <!-- Layout Manager Trigger -->
+    <button
+      class="fixed bottom-6 left-6 z-40 p-4 rounded-full bg-blue-600 text-white shadow-lg"
+      type="button"
+      (click)="toggleLayoutManager()"
+    >
+      <svg
+        class="w-5 h-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 6h16M4 12h16M4 18h16"
+        />
+      </svg>
+    </button>
+
+    <!-- Layout Manager Overlay -->
+    <div
+      *ngIf="showLayoutManager()"
+      class="fixed inset-0 z-50 flex items-end lg:items-center justify-center bg-black/50"
+    >
+      <div
+        class="bg-white rounded-t-2xl lg:rounded-2xl w-full max-h-[90vh] overflow-y-auto lg:max-w-2xl p-6"
+      >
+        <div class="flex justify-end mb-2">
+          <button
+            type="button"
+            (click)="toggleLayoutManager()"
+            class="p-1 text-gray-500 hover:text-gray-700"
+          >
+            <svg
+              class="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
         <app-json-manager
           [room]="room()"
           [importedJson]="importedJSON()"
           (import)="onImportLayout($event)"
           (importedJsonChange)="onImportedJsonChange($event)"
-        >
-        </app-json-manager>
+        ></app-json-manager>
       </div>
     </div>
   </div>

--- a/src/app/room-planner/room-planner.component.spec.ts
+++ b/src/app/room-planner/room-planner.component.spec.ts
@@ -8,9 +8,8 @@ describe('RoomPlannerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RoomPlannerComponent]
-    })
-    .compileComponents();
+      imports: [RoomPlannerComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(RoomPlannerComponent);
     component = fixture.componentInstance;
@@ -25,5 +24,11 @@ describe('RoomPlannerComponent', () => {
     component.showMobileProperties.set(false);
     component.toggleMobileProperties();
     expect(component.showMobileProperties()).toBeTrue();
+  });
+
+  it('should toggle layout manager visibility', () => {
+    component.showLayoutManager.set(false);
+    component.toggleLayoutManager();
+    expect(component.showLayoutManager()).toBeTrue();
   });
 });

--- a/src/app/room-planner/room-planner.component.ts
+++ b/src/app/room-planner/room-planner.component.ts
@@ -66,6 +66,8 @@ export class RoomPlannerComponent implements AfterViewInit {
   });
 
   readonly showMobileProperties = signal(false);
+  readonly showLayoutManager = signal(false);
+  readonly showElementGuide = signal(false);
 
   // 🧠 Redraw effect
   constructor() {
@@ -113,6 +115,7 @@ export class RoomPlannerComponent implements AfterViewInit {
 
     // Select the newly added element and bring it to front
     this.selectedId.set(element.id);
+    this.showGuide();
   }
 
   onClearElements(): void {
@@ -249,5 +252,14 @@ export class RoomPlannerComponent implements AfterViewInit {
 
   toggleMobileProperties(): void {
     this.showMobileProperties.update((v) => !v);
+  }
+
+  toggleLayoutManager(): void {
+    this.showLayoutManager.update((v) => !v);
+  }
+
+  showGuide(): void {
+    this.showElementGuide.set(true);
+    setTimeout(() => this.showElementGuide.set(false), 4000);
   }
 }


### PR DESCRIPTION
## Summary
- open layout manager from floating button
- show hint banner after adding elements
- toggle layout manager visibility with new signal
- test layout manager toggle

## Testing
- `npm run lint`
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685efb8a7ab4832c9bf4fa02218b1c4b