### PR TITLE
Improve layout design

### DIFF
--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -1,11 +1,35 @@
 <div class="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">
   <div class="container mx-auto px-4 py-8 max-w-7xl">
     <!-- Header -->
-    <div class="text-center mb-8">
-      <h1 class="text-4xl font-bold text-gray-900 mb-2">Room Planner</h1>
-      <p class="text-gray-600 text-lg">
-        Design and visualize your space with interactive elements
-      </p>
+    <div
+      class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 gap-4"
+    >
+      <div class="text-center sm:text-left">
+        <h1 class="text-4xl font-bold text-gray-900 mb-2">Room Planner</h1>
+        <p class="text-gray-600 text-lg">
+          Design and visualize your space with interactive elements
+        </p>
+      </div>
+      <button
+        class="hidden sm:inline-flex items-center gap-2 px-4 py-2 rounded-full bg-blue-600 text-white shadow hover:bg-blue-700 transition-colors"
+        type="button"
+        (click)="toggleLayoutManager()"
+      >
+        <svg
+          class="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 6h16M4 12h16M4 18h16"
+          />
+        </svg>
+        <span class="hidden md:inline">Layouts</span>
+      </button>
     </div>
 
     <!-- Room Controls Bar -->
@@ -137,7 +161,7 @@
 
     <!-- Layout Manager Trigger -->
     <button
-      class="fixed bottom-6 left-6 z-40 p-4 rounded-full bg-blue-600 text-white shadow-lg"
+      class="fixed bottom-6 left-6 z-40 p-4 rounded-full bg-blue-600 text-white shadow-lg sm:hidden"
       type="button"
       (click)="toggleLayoutManager()"
     >


### PR DESCRIPTION
## Summary
- add layout manager button in the header and hide floating button on desktop

## Testing
- `npm run lint`
- `npm run test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f014fbf10832ca3cfd59149ae9690