### PR TITLE
Add mobile controls overlay

### DIFF
--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -8,8 +8,29 @@
       </p>
     </div>
 
+    <!-- Mobile Controls Trigger -->
+    <button
+      class="fixed top-6 right-6 z-40 p-4 rounded-full bg-blue-600 text-white shadow-lg lg:hidden"
+      type="button"
+      (click)="toggleMobileControls()"
+    >
+      <svg
+        class="w-5 h-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 6h16M4 12h16M4 18h16"
+        />
+      </svg>
+    </button>
+
     <!-- Room Controls Bar -->
-    <div class="mb-6">
+    <div class="mb-6 hidden lg:block">
       <div class="bg-white rounded-2xl shadow-xl border border-gray-200 p-6">
         <app-room-controls
           [room]="room()"
@@ -131,6 +152,44 @@
             (duplicateElementEvent)="onDuplicateElement(selectedId()!)"
             (centerElementEvent)="onCenterElement(selectedId()!)"
           ></app-element-properties>
+        </div>
+      </div>
+    </div>
+
+    <!-- Mobile Controls Panel -->
+    <div *ngIf="showMobileControls()" class="lg:hidden">
+      <div class="fixed inset-0 z-50 flex items-end justify-center bg-black/50">
+        <div
+          class="bg-white rounded-t-2xl w-full max-h-[90vh] overflow-y-auto p-6"
+        >
+          <div class="flex justify-end mb-2">
+            <button
+              type="button"
+              (click)="toggleMobileControls()"
+              class="p-1 text-gray-500 hover:text-gray-700"
+            >
+              <svg
+                class="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+          <app-room-controls
+            [room]="room()"
+            (roomWidthChange)="onRoomWidthChange($event)"
+            (roomHeightChange)="onRoomHeightChange($event)"
+            (addElement)="onAddElement($event)"
+            (clearElements)="onClearElements()"
+          ></app-room-controls>
         </div>
       </div>
     </div>

--- a/src/app/room-planner/room-planner.component.spec.ts
+++ b/src/app/room-planner/room-planner.component.spec.ts
@@ -31,4 +31,10 @@ describe('RoomPlannerComponent', () => {
     component.toggleLayoutManager();
     expect(component.showLayoutManager()).toBeTrue();
   });
+
+  it('should toggle mobile controls visibility', () => {
+    component.showMobileControls.set(false);
+    component.toggleMobileControls();
+    expect(component.showMobileControls()).toBeTrue();
+  });
 });

--- a/src/app/room-planner/room-planner.component.ts
+++ b/src/app/room-planner/room-planner.component.ts
@@ -66,6 +66,7 @@ export class RoomPlannerComponent implements AfterViewInit {
   });
 
   readonly showMobileProperties = signal(false);
+  readonly showMobileControls = signal(false);
   readonly showLayoutManager = signal(false);
   readonly showElementGuide = signal(false);
 
@@ -252,6 +253,10 @@ export class RoomPlannerComponent implements AfterViewInit {
 
   toggleMobileProperties(): void {
     this.showMobileProperties.update((v) => !v);
+  }
+
+  toggleMobileControls(): void {
+    this.showMobileControls.update((v) => !v);
   }
 
   toggleLayoutManager(): void {


### PR DESCRIPTION
## Summary
- hide room controls on small screens
- add floating button to toggle mobile room controls
- implement mobile controls overlay
- cover new toggle with unit test

## Testing
- `npm run lint`
- `npm run test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685f0290f2bc832cbd5a5ff508d05704