### PR TITLE
Implement separate import/export layout controls

### DIFF
--- a/src/app/room-planner/components/json-manager.component.ts
+++ b/src/app/room-planner/components/json-manager.component.ts
@@ -14,9 +14,12 @@ import { RoomElement } from '../interfaces/room-element.interface';
         </p>
       </div>
 
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <div
+        class="grid grid-cols-1 gap-8"
+        [ngClass]="{ 'lg:grid-cols-2': view === 'both' }"
+      >
         <!-- Export Section -->
-        <div class="space-y-4">
+        <div class="space-y-4" *ngIf="view !== 'import'">
           <div class="flex items-center gap-2 mb-4">
             <svg
               class="w-5 h-5 text-blue-600"
@@ -73,7 +76,7 @@ import { RoomElement } from '../interfaces/room-element.interface';
         </div>
 
         <!-- Import Section -->
-        <div class="space-y-4">
+        <div class="space-y-4" *ngIf="view !== 'export'">
           <div class="flex items-center gap-2 mb-4">
             <svg
               class="w-5 h-5 text-green-600"
@@ -93,7 +96,10 @@ import { RoomElement } from '../interfaces/room-element.interface';
 
           <div class="space-y-4">
             <div>
-              <label for="json-import" class="block text-sm font-medium text-gray-700 mb-2">
+              <label
+                for="json-import"
+                class="block text-sm font-medium text-gray-700 mb-2"
+              >
                 Paste JSON Layout
               </label>
               <textarea
@@ -156,6 +162,7 @@ import { RoomElement } from '../interfaces/room-element.interface';
 export class JsonManagerComponent {
   @Input() room!: Room;
   @Input() importedJson = '';
+  @Input() view: 'export' | 'import' | 'both' = 'both';
 
   @Output() import = new EventEmitter<Room>();
   @Output() importedJsonChange = new EventEmitter<string>();
@@ -174,7 +181,7 @@ export class JsonManagerComponent {
       const parsed = JSON.parse(this.importedJson);
       if (parsed.width && parsed.height) {
         let staticElements: RoomElement[] = [];
-        
+
         // If it's the new format with staticElements
         if (parsed.staticElements) {
           staticElements = parsed.staticElements;

--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -218,26 +218,49 @@
       </div>
     </div>
 
-    <!-- Layout Manager Trigger -->
-    <button
-      class="fixed bottom-6 left-6 z-40 p-4 rounded-full bg-blue-600 text-white shadow-lg sm:hidden"
-      type="button"
-      (click)="toggleLayoutManager()"
-    >
-      <svg
-        class="w-5 h-5"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
+    <!-- Export / Import Triggers -->
+    <div class="fixed bottom-6 left-6 z-40 flex flex-col gap-3 sm:hidden">
+      <button
+        class="p-4 rounded-full bg-blue-600 text-white shadow-lg"
+        type="button"
+        (click)="toggleExportManager()"
+        title="Export Layout"
       >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M4 6h16M4 12h16M4 18h16"
-        />
-      </svg>
-    </button>
+        <svg
+          class="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+      </button>
+      <button
+        class="p-4 rounded-full bg-green-600 text-white shadow-lg"
+        type="button"
+        (click)="toggleImportManager()"
+        title="Import Layout"
+      >
+        <svg
+          class="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"
+          />
+        </svg>
+      </button>
+    </div>
 
     <!-- Layout Manager Overlay -->
     <div
@@ -273,6 +296,78 @@
           [importedJson]="importedJSON()"
           (import)="onImportLayout($event)"
           (importedJsonChange)="onImportedJsonChange($event)"
+        ></app-json-manager>
+      </div>
+    </div>
+
+    <!-- Export Layout Overlay -->
+    <div
+      *ngIf="showExportManager()"
+      class="fixed inset-0 z-50 flex items-end lg:items-center justify-center bg-black/50"
+    >
+      <div
+        class="bg-white rounded-t-2xl lg:rounded-2xl w-full max-h-[90vh] overflow-y-auto lg:max-w-2xl p-6"
+      >
+        <div class="flex justify-end mb-2">
+          <button
+            type="button"
+            (click)="toggleExportManager()"
+            class="p-1 text-gray-500 hover:text-gray-700"
+          >
+            <svg
+              class="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+        <app-json-manager [room]="room()" view="export"></app-json-manager>
+      </div>
+    </div>
+
+    <!-- Import Layout Overlay -->
+    <div
+      *ngIf="showImportManager()"
+      class="fixed inset-0 z-50 flex items-end lg:items-center justify-center bg-black/50"
+    >
+      <div
+        class="bg-white rounded-t-2xl lg:rounded-2xl w-full max-h-[90vh] overflow-y-auto lg:max-w-2xl p-6"
+      >
+        <div class="flex justify-end mb-2">
+          <button
+            type="button"
+            (click)="toggleImportManager()"
+            class="p-1 text-gray-500 hover:text-gray-700"
+          >
+            <svg
+              class="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+        <app-json-manager
+          [room]="room()"
+          [importedJson]="importedJSON()"
+          (import)="onImportLayout($event)"
+          (importedJsonChange)="onImportedJsonChange($event)"
+          view="import"
         ></app-json-manager>
       </div>
     </div>

--- a/src/app/room-planner/room-planner.component.spec.ts
+++ b/src/app/room-planner/room-planner.component.spec.ts
@@ -37,4 +37,16 @@ describe('RoomPlannerComponent', () => {
     component.toggleMobileControls();
     expect(component.showMobileControls()).toBeTrue();
   });
+
+  it('should toggle export manager visibility', () => {
+    component.showExportManager.set(false);
+    component.toggleExportManager();
+    expect(component.showExportManager()).toBeTrue();
+  });
+
+  it('should toggle import manager visibility', () => {
+    component.showImportManager.set(false);
+    component.toggleImportManager();
+    expect(component.showImportManager()).toBeTrue();
+  });
 });

--- a/src/app/room-planner/room-planner.component.ts
+++ b/src/app/room-planner/room-planner.component.ts
@@ -68,6 +68,8 @@ export class RoomPlannerComponent implements AfterViewInit {
   readonly showMobileProperties = signal(false);
   readonly showMobileControls = signal(false);
   readonly showLayoutManager = signal(false);
+  readonly showExportManager = signal(false);
+  readonly showImportManager = signal(false);
   readonly showElementGuide = signal(false);
 
   // 🧠 Redraw effect
@@ -261,6 +263,14 @@ export class RoomPlannerComponent implements AfterViewInit {
 
   toggleLayoutManager(): void {
     this.showLayoutManager.update((v) => !v);
+  }
+
+  toggleExportManager(): void {
+    this.showExportManager.update((v) => !v);
+  }
+
+  toggleImportManager(): void {
+    this.showImportManager.update((v) => !v);
   }
 
   showGuide(): void {


### PR DESCRIPTION
## Summary
- add `view` input to `JsonManagerComponent`
- add export/import floating buttons
- open dedicated overlays for export or import
- test toggle methods for new overlays

## Testing
- `npm run lint`
- `npm run test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_685f22ca4cfc832c9030a3a0a3e5bbf3