### PR TITLE
Fix canvas width on small screens

### DIFF
--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -80,14 +80,16 @@
             </div>
           </div>
           <div class="flex justify-center overflow-auto touch-pan-y">
-            <div class="max-w-full max-h-[500px] overflow-auto relative">
+            <div
+              class="max-w-full max-h-[500px] overflow-auto relative w-full sm:w-auto"
+            >
               <canvas
                 #canvas
                 appCanvasInteraction
                 [room]="room()"
                 [selectedId]="selectedId()"
                 (interaction)="onCanvasInteraction($event)"
-                class="block max-w-none border bg-white touch-none select-none"
+                class="block max-w-none border bg-white touch-none select-none w-full sm:w-auto h-auto"
               >
               </canvas>
               <div


### PR DESCRIPTION
## Summary
- make canvas and wrapper responsive for small screens

## Testing
- `npm run lint`
- `npm run test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685f245d3230832ca9016e1595e6b483