### PR TITLE
Remove layout manager subtitle

### DIFF
--- a/src/app/room-planner/components/json-manager.component.ts
+++ b/src/app/room-planner/components/json-manager.component.ts
@@ -12,9 +12,6 @@ import { RoomElement } from '../interfaces/room-element.interface';
       <!-- Header -->
       <div class="text-center">
         <h2 class="text-2xl font-bold text-gray-900 mb-2">Layout Manager</h2>
-        <p class="text-gray-600">
-          Export your current layout or import an existing one
-        </p>
       </div>
 
       <div


### PR DESCRIPTION
## Summary
- remove subtitle from layout manager

## Testing
- `npm run lint`
- `npm run test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685f7b3a09c8832cba3fc5e8872cae54