### PR TITLE
Remove mobile panel top border

### DIFF
--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -148,7 +148,7 @@
         *ngIf="showMobileProperties() && selectedElement()"
       >
         <div
-          class="fixed inset-x-0 bottom-0 z-50 bg-white border-t rounded-t-2xl shadow-2xl p-6"
+          class="fixed inset-x-0 bottom-0 z-50 bg-white rounded-t-2xl shadow-2xl p-6"
         >
           <div class="flex justify-end mb-2">
             <button


### PR DESCRIPTION
## Summary
- drop `border-t` from the mobile properties panel container

## Testing
- `npm run lint`
- `npm run test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8ccc053c832cb439af6e8fc5f744