### PR TITLE
Add CDK drag-drop support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
+    "@angular/cdk": "^17.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/room-planner/components/room-controls.component.html
+++ b/src/app/room-planner/components/room-controls.component.html
@@ -69,6 +69,11 @@
       <span class="text-xs text-gray-600">Tables:</span>
       <button
         appButtonFeedback
+        cdkDrag
+        [cdkDragData]="{
+          elementType: elementTypeEnum.TABLE,
+          shapeType: shapeTypeEnum.RECTANGLE,
+        }"
         (click)="onAddElement(elementTypeEnum.TABLE, shapeTypeEnum.RECTANGLE)"
         class="p-2 sm:p-1.5 bg-blue-600 text-white rounded hover:bg-blue-700 focus:ring-1 focus:ring-blue-500 transition-colors"
         title="Add Rectangle Table"
@@ -84,6 +89,11 @@
       </button>
       <button
         appButtonFeedback
+        cdkDrag
+        [cdkDragData]="{
+          elementType: elementTypeEnum.TABLE,
+          shapeType: shapeTypeEnum.CIRCLE,
+        }"
         (click)="onAddElement(elementTypeEnum.TABLE, shapeTypeEnum.CIRCLE)"
         class="p-2 sm:p-1.5 bg-blue-600 text-white rounded hover:bg-blue-700 focus:ring-1 focus:ring-blue-500 transition-colors"
         title="Add Round Table"
@@ -104,6 +114,11 @@
       <span class="text-xs text-gray-600">Static:</span>
       <button
         appButtonFeedback
+        cdkDrag
+        [cdkDragData]="{
+          elementType: elementTypeEnum.STATIC,
+          shapeType: shapeTypeEnum.RECTANGLE,
+        }"
         (click)="onAddElement(elementTypeEnum.STATIC, shapeTypeEnum.RECTANGLE)"
         class="p-2 sm:p-1.5 bg-gray-600 text-white rounded hover:bg-gray-700 focus:ring-1 focus:ring-gray-500 transition-colors"
         title="Add Rectangle Static Element"
@@ -119,6 +134,11 @@
       </button>
       <button
         appButtonFeedback
+        cdkDrag
+        [cdkDragData]="{
+          elementType: elementTypeEnum.STATIC,
+          shapeType: shapeTypeEnum.CIRCLE,
+        }"
         (click)="onAddElement(elementTypeEnum.STATIC, shapeTypeEnum.CIRCLE)"
         class="p-2 sm:p-1.5 bg-gray-600 text-white rounded hover:bg-gray-700 focus:ring-1 focus:ring-gray-500 transition-colors"
         title="Add Circle Static Element"

--- a/src/app/room-planner/components/room-controls.component.ts
+++ b/src/app/room-planner/components/room-controls.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { ButtonFeedbackDirective } from '../directives/button-feedback.directive';
 import {
   ElementType,
@@ -12,7 +13,7 @@ import { Room } from '../interfaces/room.interface';
 @Component({
   selector: 'app-room-controls',
   standalone: true,
-  imports: [CommonModule, ButtonFeedbackDirective],
+  imports: [CommonModule, DragDropModule, ButtonFeedbackDirective],
   templateUrl: './room-controls.component.html',
 })
 export class RoomControlsComponent {

--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -21,6 +21,8 @@
     <div class="flex justify-center overflow-auto touch-pan-y">
       <div
         class="max-w-full max-h-[500px] overflow-auto relative w-full sm:w-auto"
+        cdkDropList
+        (cdkDropListDropped)="onDragDrop($event)"
       >
         <canvas
           #canvas


### PR DESCRIPTION
## Summary
- integrate `@angular/cdk` into dependencies
- enable CDK DragDrop in RoomPlanner component
- register CDK module in RoomControls component and allow dragging of add-item buttons
- handle drop events on the canvas area

## Testing
- `npm run lint`
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685fb8169598832c84fe021ada237ebc