### PR TITLE
Remove Quick Actions UI

### DIFF
--- a/src/app/room-planner/components/element-properties.component.html
+++ b/src/app/room-planner/components/element-properties.component.html
@@ -195,47 +195,6 @@
       </div>
     </div>
 
-    <!-- Quick Actions -->
-    <div class="space-y-2">
-      <span class="text-xs font-medium text-gray-700">Quick Actions</span>
-      <div class="grid grid-cols-2 gap-1">
-        @if (selectedElement.elementType === ElementTypeEnum.TABLE) {
-          <button
-            appButtonFeedback
-            type="button"
-            (click)="setPresetSize(selectedElement, 0.8, 0.8)"
-            class="px-2 py-1 text-xs bg-blue-50 text-blue-700 rounded hover:bg-blue-100 transition-colors"
-          >
-            Small Table
-          </button>
-          <button
-            appButtonFeedback
-            type="button"
-            (click)="setPresetSize(selectedElement, 1.6, 0.8)"
-            class="px-2 py-1 text-xs bg-blue-50 text-blue-700 rounded hover:bg-blue-100 transition-colors"
-          >
-            Large Table
-          </button>
-        }
-        <button
-          appButtonFeedback
-          type="button"
-          (click)="centerElement()"
-          class="px-2 py-1 text-xs bg-gray-50 text-gray-700 rounded hover:bg-gray-100 transition-colors"
-        >
-          Center
-        </button>
-        <button
-          appButtonFeedback
-          type="button"
-          (click)="duplicateElement()"
-          class="px-2 py-1 text-xs bg-green-50 text-green-700 rounded hover:bg-green-100 transition-colors"
-        >
-          Duplicate
-        </button>
-      </div>
-    </div>
-
     <!-- Delete Button -->
     <div class="mt-8">
       <button

--- a/src/app/room-planner/components/element-properties.component.ts
+++ b/src/app/room-planner/components/element-properties.component.ts
@@ -13,7 +13,6 @@ import {
   ElementType,
   ElementTypeEnum,
   RoomElement,
-  ShapeTypeEnum,
 } from '../interfaces/room-element.interface';
 
 @Component({
@@ -25,8 +24,6 @@ export class ElementPropertiesComponent implements OnChanges {
   @Input() selectedElement: RoomElement | null = null;
   @Output() updateElement = new EventEmitter<Partial<RoomElement>>();
   @Output() deleteElement = new EventEmitter<void>();
-  @Output() duplicateElementEvent = new EventEmitter<void>();
-  @Output() centerElementEvent = new EventEmitter<void>();
 
   private aspectRatio = 1;
 
@@ -34,7 +31,6 @@ export class ElementPropertiesComponent implements OnChanges {
   lockAspectRatio = signal(false);
   ROOM_PLANNER_CONSTANTS = ROOM_PLANNER_CONSTANTS;
   ElementTypeEnum = ElementTypeEnum;
-  ShapeTypeEnum = ShapeTypeEnum;
 
   ngOnChanges() {
     if (this.selectedElement) {
@@ -145,32 +141,6 @@ export class ElementPropertiesComponent implements OnChanges {
       default:
         return 'bg-gray-100 text-gray-800';
     }
-  }
-
-  setPresetSize(
-    element: RoomElement,
-    widthMeters: number,
-    heightMeters: number,
-  ): void {
-    let finalHeightMeters = heightMeters;
-    if (element.shapeType === ShapeTypeEnum.CIRCLE) {
-      finalHeightMeters = widthMeters;
-    }
-    const widthPixels = this.metersToPixels(widthMeters);
-    const heightPixels = this.metersToPixels(finalHeightMeters);
-    this.updateElement.emit({
-      ...element,
-      width: widthPixels,
-      height: heightPixels,
-    });
-  }
-
-  centerElement(): void {
-    this.centerElementEvent.emit();
-  }
-
-  duplicateElement(): void {
-    this.duplicateElementEvent.emit();
   }
 
   private isValidColor(color: string): boolean {

--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -84,8 +84,6 @@
         [selectedElement]="selectedElement()"
         (updateElement)="onUpdateElement(selectedId()!, $event)"
         (deleteElement)="onDeleteElement(selectedId()!)"
-        (duplicateElementEvent)="onDuplicateElement(selectedId()!)"
-        (centerElementEvent)="onCenterElement(selectedId()!)"
       ></app-element-properties>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- remove Quick Actions section from element properties component
- drop event outputs and related methods
- update room planner template to stop using removed events

## Testing
- `npm run lint`
- `npm run test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860528f7e50832c9b01a8b3733df479