### PR TITLE
Fix mobile width for properties panel

### DIFF
--- a/src/app/room-planner/room-planner.component.html
+++ b/src/app/room-planner/room-planner.component.html
@@ -61,7 +61,7 @@
   <!-- Bottom Panel: Element Properties (when selected) -->
   <div
     *ngIf="selectedElement()"
-    class="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-10 max-w-md w-full mx-4"
+    class="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-10 w-full max-w-xs sm:max-w-md mx-4"
   >
     <div class="bg-white rounded-lg shadow-lg p-4 border">
       <app-element-properties


### PR DESCRIPTION
## Summary
- narrow properties panel on mobile screens to max-w-xs

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686d470b57c4832cab4167d5c4220b26