### PR TITLE
Improve touch gesture UX

### DIFF
--- a/src/app/room-planner/directives/canvas-interaction.directive.spec.ts
+++ b/src/app/room-planner/directives/canvas-interaction.directive.spec.ts
@@ -7,12 +7,16 @@ import {
   CanvasInteractionEventTypeEnum,
 } from '../interfaces/canvas-interactio-event.interface';
 import { Room } from '../interfaces/room.interface';
+import {
+  ElementTypeEnum,
+  RoomElement,
+} from '../interfaces/room-element.interface';
 
 @Component({
   template: `<canvas
     appCanvasInteraction
     [room]="room"
-    [selectedId]="null"
+    [selectedId]="selectedId"
     [zoom]="zoom"
     (interaction)="onInteraction($event)"
   ></canvas>`,
@@ -29,6 +33,7 @@ class TestHostComponent {
     staticElements: [],
   };
   zoom = 1;
+  selectedId: string | null = null;
   event?: CanvasInteractionEvent;
 
   onInteraction(evt: CanvasInteractionEvent) {
@@ -73,5 +78,68 @@ describe('CanvasInteractionDirective', () => {
 
     expect(host.event?.type).not.toBe(CanvasInteractionEventTypeEnum.ZOOM);
     expect(host.zoom).toBe(1);
+  });
+
+  it('should pinch zoom canvas when touches start outside selected element', () => {
+    host.room.staticElements.push({
+      id: 'el1',
+      x: 10,
+      y: 10,
+      width: 30,
+      height: 30,
+      color: '#ccc',
+      label: 'el',
+      elementType: ElementTypeEnum.STATIC,
+      shapeType: 'rect',
+      zIndex: 1,
+    } as RoomElement);
+    host.selectedId = 'el1';
+    fixture.detectChanges();
+
+    const canvas = fixture.debugElement.query(By.css('canvas'))
+      .nativeElement as HTMLCanvasElement;
+
+    const t1Start = new Touch({
+      identifier: 1,
+      target: canvas,
+      clientX: 80,
+      clientY: 80,
+    });
+    const t2Start = new Touch({
+      identifier: 2,
+      target: canvas,
+      clientX: 90,
+      clientY: 90,
+    });
+    canvas.dispatchEvent(
+      new TouchEvent('touchstart', {
+        touches: [t1Start, t2Start],
+        targetTouches: [t1Start, t2Start],
+        changedTouches: [t1Start, t2Start],
+      }),
+    );
+
+    const t1Move = new Touch({
+      identifier: 1,
+      target: canvas,
+      clientX: 70,
+      clientY: 70,
+    });
+    const t2Move = new Touch({
+      identifier: 2,
+      target: canvas,
+      clientX: 100,
+      clientY: 100,
+    });
+    canvas.dispatchEvent(
+      new TouchEvent('touchmove', {
+        touches: [t1Move, t2Move],
+        targetTouches: [t1Move, t2Move],
+        changedTouches: [t1Move, t2Move],
+      }),
+    );
+    fixture.detectChanges();
+
+    expect(host.event?.type).toBe(CanvasInteractionEventTypeEnum.ZOOM);
   });
 });


### PR DESCRIPTION
## Summary
- allow two finger panning/zooming even when an element is selected
- check touch start position before resizing
- cover new behaviour in tests

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686d47a6c1e4832ca99b143a8611c6a8