### PR TITLE
Fix dropdown button height

### DIFF
--- a/src/app/room-planner/components/add-elements-dropdown.component.ts
+++ b/src/app/room-planner/components/add-elements-dropdown.component.ts
@@ -16,7 +16,7 @@ import {
     <div class="relative">
       <button
         appButtonFeedback
-        class="flex items-center gap-2 px-2 py-1 rounded bg-blue-600 text-white shadow-sm hover:bg-blue-700 transition-colors"
+        class="flex items-center gap-2 px-2 py-1 text-sm rounded bg-blue-600 text-white shadow-sm hover:bg-blue-700 transition-colors"
         type="button"
         (click)="toggleDropdown()"
         title="Add Elements"


### PR DESCRIPTION
## Summary
- adjust AddElements dropdown button text size so its height matches other controls

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686d8b03d84c832ca4378a8aba6f6412