### PR TITLE
Prevent input zoom on focus

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -99,6 +99,7 @@
     }
   },
   "cli": {
-    "schematicCollections": ["angular-eslint"]
+    "schematicCollections": ["angular-eslint"],
+    "analytics": false
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>RoomPlanner</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>RoomPlanner</title>
+    <base href="/" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
 </html>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,3 +16,10 @@ body {
   line-height: 1.6;
   scroll-behavior: smooth;
 }
+
+/* Prevent iOS from zooming inputs on focus */
+input,
+textarea,
+select {
+  font-size: 16px;
+}


### PR DESCRIPTION
## Summary
- stop browsers from zooming when focusing on inputs
- disable Angular CLI analytics

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686e500d5a90832cb5c7d1ff0b9f5bfd