### PR TITLE
Revert latest input zoom style

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,10 +16,3 @@ body {
   line-height: 1.6;
   scroll-behavior: smooth;
 }
-
-/* Prevent iOS from zooming inputs on focus */
-input,
-textarea,
-select {
-  font-size: 16px;
-}


### PR DESCRIPTION
## Summary
- remove iOS zoom override styles from `src/styles.scss`

## Testing
- `npx pnpm run lint`
- `npx pnpm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686e57635170832cb04a7dd7c10b2495